### PR TITLE
thursday work

### DIFF
--- a/server.R
+++ b/server.R
@@ -10,6 +10,8 @@ function(input, output, session) {
   disable("covariates")
   disable("select_all")
   disable("complete_case_probability") # this needs to be disabled too*
+  disable("run_regression") # button only unlocks when a valid dataset is uploaded
+  disable("proxy_variables") # same
 
   # Load data specified by user
   data <- reactive({
@@ -26,17 +28,20 @@ function(input, output, session) {
   observe({
     req(data())
     all_vars <- names(data())
+    
 
     updateSelectInput(session, "outcome", choices = all_vars)
     updateSelectInput(session, "treatment", choices = all_vars)
     updateSelectizeInput(session, "covariates", choices = all_vars)
-    updateSelectInput(session, "complete_case_probability", choices = all_vars) # this needed to be updated as well when a dataset is added. 
+    updateSelectInput(session, "complete_case_probability", choices = all_vars)
+    updateSelectInput(session, "proxy_variables", choices = all_vars)# this needed to be updated as well when a dataset is added. 
 
     enable("outcome")
     enable("treatment")
     enable("covariates")
     enable("select_all")
     enable("complete_case_probability")
+    enable("proxy_variables")
   })
 
   # Don't want anything getting double selected. If something is selected as
@@ -58,20 +63,29 @@ function(input, output, session) {
     req(data())
     all_vars <- names(data())
     exclude_vars <- c()
-    exclude_ccp_vars <- c() # need to make a new one that includes Y, A, AND X**
+    exclude_ccp_vars <- c()# need to make a new one that includes Y, A, AND X**
+    exclude_proxy_vars <- c() # same as above, also disclude ccp column
     if (!is.null(input$outcome) && input$outcome != "") {
       exclude_vars <- c(exclude_vars, input$outcome)
       exclude_ccp_vars <- c(exclude_vars, input$outcome) 
+      exclude_proxy_vars <- c(exclude_vars, input$outcome) 
     }
     if (!is.null(input$treatment) && input$treatment != "") {
       exclude_vars <- c(exclude_vars, input$treatment)
       exclude_ccp_vars <- c(exclude_vars, input$treatment)
+      exclude_proxy_vars <- c(exclude_vars, input$treatment) 
     }
     if (!is.null(input$covariates) && length(input$covariates) > 0) {
-      exclude_ccp_vars <- c(exclude_vars, input$covariates) # only need to updatee ccp vars here
+      exclude_ccp_vars <- c(exclude_vars, input$covariates) # only need to updatee ccp vars her
+      exclude_proxy_vars <- c(exclude_vars, input$covariates)
+    }
+    if (!is.null(input$complete_case_proability) && length(input$complete_case_probability) > 0) {
+      exclude_ccp_vars <- c(exclude_vars, input$complete_case_probability) # only need to update proxy vars from here on
+      exclude_proxy_vars <- c(exclude_vars, input$complete_case_probability)
     }
     available_covars <- setdiff(all_vars, exclude_vars)
     available_ccp_vars <- setdiff(all_vars, exclude_ccp_vars)
+    available_proxy_vars <- setdiff(all_vars, exclude_proxy_vars)
 
     updateSelectizeInput(session, "covariates",
                          choices = available_covars,
@@ -79,10 +93,15 @@ function(input, output, session) {
     
     updateSelectInput(session, "complete_case_probability",
                       choices = available_ccp_vars, # same logic here with new variable
-                      selected = if (input$`complete_case_probability` %in% available_ccp_vars) input$`complete_case_probability` else NULL)
-  }) # essentially 
+                      selected = "")
+                      
+    updateSelectInput(session, "proxy_variables",
+                      choices = available_proxy_vars,
+                      selected = ""
+    )
+  }) # essentially only allow non-conflicting columns else null
 
-  # Button for letting user select all available covariates
+  # Button for letting user select all available covariates 
   # Will select all variables excluding what's selected for Y and A, since a variable
   # can't be a covariate (in X) and an outcome/treatment simultaneously
   observeEvent(input$select_all, {
@@ -102,6 +121,57 @@ function(input, output, session) {
     updateSelectizeInput(session, "covariates", selected = available_covars)
   })
   
+  # Logic for handling correct data
+  
+  observe({
+    req(data(), input$treatment, input$outcome)
+    treatment_values <- data()[[input$treatment]]
+    outcome_values <- data()[[input$outcome]]
+    
+    covariate_values <- NULL
+    if (!is.null(input$covariates) && length(input$covariates) > 0) {
+      covariate_values <- data()[, input$covariates, drop = FALSE]
+    } 
+    
+    ccp_values <- NULL
+    if (!is.null(input$complete_case_probability) && length(input$complete_case_probability) > 0) {
+      ccp_values <- data()[, input$complete_case_probability, drop = FALSE]
+    } 
+    
+    proxy_values <- NULL
+    if (!is.null(input$proxy_variables) && length(input$proxy_variables > 0)) {
+      proxy_values <- data()[, input$proxy_variables, drop = FALSE]
+    } 
+    
+    errors <- list() # make it a list of errors so it can dynamically change 
+    
+    if (!all(treatment_values %in% c(0,1))) {
+      errors <- append(errors, "Your treatment column must contain only 1's and 0's")
+      }
+    if(!is.numeric(outcome_values)) {
+      errors <- append(errors, "Your outcome column must be entirely numeric")
+    }
+    if(!is.null(input$covariates) && !is.numeric(covariate_values)) {
+      errors <- append(errors, "Your covariates column must be entirely numeric")
+    }
+    if(!is.null(input$complete_case_probability) && !is.numeric(ccp_values)) {
+      errors <- append(errors, "your complete case probabilties must be entirely numeric probabilities ∈ [0,1] ")
+    }
+    if(!is.null(input$proxy_variables) && !is.numeric(ccp_values)) {
+      errors <- append(errors, "your proxy variables must be entirely numeric")
+    }
+    if (length(errors) > 0) { # only disable the button if there are any errors
+      disable("run_regression")
+      output$validation_message <- renderUI({
+        div(style = "color: red;", paste("ERRORS[",length(errors),"]: ", errors, collapse = ", ")) # errors are neatly listed on the right
+      })
+    } else {
+      enable("run_regression")
+      output$validation_message <- renderUI({NULL}) # not needed
+    }
+  })
+
+
 
   # Preview of the data
   # Don't know if we'll actually keep this feature but it's here for now

--- a/ui.R
+++ b/ui.R
@@ -95,11 +95,16 @@ fluidPage(
                    tippy_this("targetted_maximum_label", "Targeted Maximum Likelihood Estimation (TML) is an alternative approach to estimate counterfactual means and treatment effects. Unlike the default one-step debiased estimators, TML refines the final estimators by targeting the likelihood function to improve accuracy. Set `tml = TRUE` to use this asymptotically equivalent method.", placement = "right", animation= "shift away", theme="light-border"), 
                    
                    tags$label(id = "truncate_propensity_label", "Trimming of propensity scores"),
-                   numericInput("truncate-propensity", NULL, value = 0, min = 0, max = 1),
-                   tippy_this("truncate_propensity_label", "Trimming of propensity scores helps prevent unstable estimators by limiting extreme values, which are used in inverse probability weights. By default, drcmd trims scores at 0.025 and 0.975. You can adjust this range by setting the `cutoff` argument to specify custom limits (e.g., setting `cutoff = 0` avoids trimming) The number you select is symmetrical. Needs ∈ [0,1]", placement = "right", animation= "shift away", theme="light-border"), 
+                   numericInput("truncate-propensity", NULL, value = 0, min = 0, max = 0.5),
+                   tippy_this("truncate_propensity_label", "Trimming of propensity scores helps prevent unstable estimators by limiting extreme values, which are used in inverse probability weights. By default, drcmd trims scores at 0.025 and 0.975. You can adjust this range by setting the `cutoff` argument to specify custom limits (e.g., setting `cutoff = 0` avoids trimming) The number you select is symmetrical. Value ∈ [0,0.5]", placement = "right", animation= "shift away", theme="light-border"), 
                    
                    selectInput('complete_case_probability', '',
                                label = tags$span("Select complete case probability column", id = "complete_case_label"),
+                               choices=NULL,
+                               multiple=FALSE),
+                   
+                   selectInput('proxy_variables', '', # added this for proxy
+                               label = tags$span("Select proxy variable column", id = "proxy_variables_label"),
                                choices=NULL,
                                multiple=FALSE),
                    
@@ -109,17 +114,17 @@ fluidPage(
                                multiple=FALSE),
                    
                    selectInput('outcome_learners', '',
-                               label = tags$span("Selected outcome learner", id = "outcome_learners_label"),
+                               label = tags$span("Select outcome learner", id = "outcome_learners_label"),
                                choices=learners,
                                multiple=FALSE),
                    
                    selectInput('pseudo-outcome_learners', '',
-                               label = tags$span("Selected pseudo-outcome learner", id = "psuedo-learners_label"),
+                               label = tags$span("Select pseudo-outcome learner", id = "psuedo-learners_label"),
                                choices=learners,
                                multiple=FALSE),
                    
                    selectInput('complete_case_probability_learners', '',
-                               label = tags$span("Selected complete-case probability learner", id = "complete_case_learners_label"),
+                               label = tags$span("Select complete-case probability learner", id = "complete_case_learners_label"),
                                choices=learners,
                                multiple=FALSE),
                    
@@ -173,11 +178,17 @@ fluidPage(
                  animation = "shift-away",
                  theme = "light-border"),
       
+      tippy_this("proxy_variables_label",
+                 tooltip = "TESTING, TEST", # I dont really know how to describe these well in context
+                 placement = "right",
+                 animation = "shift-away",
+                 theme = "light-border"),
       
       
       
       # Button to run the regression.
       actionButton("run_regression", "Run drcmd")
+      
     ),
     
     # Main panel on the right for output
@@ -186,7 +197,8 @@ fluidPage(
       tableOutput("datatable"),
       hr(),
       h4("Results"),
-      verbatimTextOutput("drcmd_output")
+      verbatimTextOutput("drcmd_output"),
+      uiOutput("validation_message")
     )
   )
 )


### PR DESCRIPTION
-Added logic that disables the run regression button unless the data is formatted properly, treatment in {0,1} complete case probabilities only holding numeric values within [0,1] proxy variables must be entirely numeric error message with proper error is diplayed on the main panel to the right
-Added proxy variables column selector which demands numeric values, also hover message (but I didn't know how to describe these) 
-Logic to prevent all of the data columns from overlapping, only available columns in data are ones that they haven't already chosen for another variable